### PR TITLE
invoke displayGalleryItemsNum as soon as the page loads

### DIFF
--- a/public/JavaScript/gallery-dom.js
+++ b/public/JavaScript/gallery-dom.js
@@ -68,6 +68,8 @@ if (typeof document !== 'undefined') {
         radio.checked = false
       })
     }
+
+    displayGalleryItemsNum('.gallery-items')
   })
 }
 module.exports = { displayGalleryItemsNum }


### PR DESCRIPTION
# PR  14-02-24
## Overview
In this PR we display how many gallery-items are present as soon as you load / enter the page
## Key Changes :
 1) gallery-dom.js :
    - Invoke the function `displayGalleryItemsNum('.gallery-items')` when page is loading so when you enter in the page you have the total amount of item