### PR TITLE
display counter whem page loads

### DIFF
--- a/public/JavaScript/gallery-dom.js
+++ b/public/JavaScript/gallery-dom.js
@@ -68,8 +68,6 @@ if (typeof document !== 'undefined') {
         radio.checked = false
       })
     }
-
-    displayGalleryItemsNum('.gallery-items')
     getPets('#img-container')
   })
 }
@@ -104,6 +102,6 @@ async function getPets (item) {
             </div></div>\n
             `)
   })
+  displayGalleryItemsNum('.gallery-items')
 }
-
 module.exports = { displayGalleryItemsNum, getPets }


### PR DESCRIPTION
#76 
# PR 16-02-24 : load counter with page
## Overview
In this PR we load the counter with the page 
## Key Changes :
 1) gallery-dom.js : 
    - Call the function `displayGalleryItemsNum('.gallery-items')` on the `getPets` function so it loads with the elements right away when the page loads